### PR TITLE
Add methods for shortest prefix matching

### DIFF
--- a/src/map/entry.rs
+++ b/src/map/entry.rs
@@ -222,6 +222,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(clippy::unwrap_or_default)]
     #[inline(always)]
     pub fn or_default(self) -> &'a mut T {
         self.or_insert_with(Default::default)

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -133,7 +133,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get_lpm<'a, 'b>(&'a self, prefix: &'b P) -> Option<(&'a P, &'a T)> {
+    pub fn get_lpm<'a>(&'a self, prefix: &P) -> Option<(&'a P, &'a T)> {
         let mut idx = 0;
         let mut best_match: Option<(&P, &T)> = None;
         loop {

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -59,6 +59,26 @@ impl<P: Prefix> PrefixSet<P> {
         self.0.get_lpm(prefix).map(|(p, _)| p)
     }
 
+    /// Get the shortest prefix in the set that contains the given preifx.
+    ///
+    /// ```
+    /// # use prefix_trie::*;
+    /// # use ipnet::Ipv4Net;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut set: PrefixSet<Ipv4Net> = PrefixSet::new();
+    /// set.insert("192.168.1.0/24".parse()?);
+    /// set.insert("192.168.0.0/23".parse()?);
+    /// assert_eq!(set.get_spm(&"192.168.1.1/32".parse()?), Some(&"192.168.0.0/23".parse()?));
+    /// assert_eq!(set.get_spm(&"192.168.1.0/24".parse()?), Some(&"192.168.0.0/23".parse()?));
+    /// assert_eq!(set.get_spm(&"192.168.0.0/23".parse()?), Some(&"192.168.0.0/23".parse()?));
+    /// assert_eq!(set.get_spm(&"192.168.2.0/24".parse()?), None);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_spm<'a>(&'a self, prefix: &P) -> Option<&'a P> {
+        self.0.get_spm_prefix(prefix)
+    }
+
     /// Adds a value to the set.
     ///
     /// Returns whether the value was newly inserted. That is:

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -55,7 +55,7 @@ impl<P: Prefix> PrefixSet<P> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get_lpm<'a, 'b>(&'a self, prefix: &'b P) -> Option<&'a P> {
+    pub fn get_lpm<'a>(&'a self, prefix: &P) -> Option<&'a P> {
         self.0.get_lpm(prefix).map(|(p, _)| p)
     }
 


### PR DESCRIPTION
I'm working on a project where these methods would be remarkably useful. This PR also resolves all the Clippy lints.