### PR TITLE
support search_covering

### DIFF
--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -252,6 +252,39 @@ where
         }
     }
 
+    /// Returns a Vec of all nodes that are covered by the given `prefix`.
+    ///
+    /// ```
+    /// # use prefix_trie::*;
+    /// # #[cfg(feature = "ipnet")]
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut pm: PrefixMap<ipnet::Ipv4Net, _> = PrefixMap::new();
+    /// pm.insert("10.0.0.0/8".parse()?, 0);
+    /// pm.insert("10.1.0.0/16".parse()?, 1);
+    /// pm.insert("10.1.1.0/24".parse()?, 2);
+    /// pm.insert("10.1.2.0/24".parse()?, 4);
+    /// assert_eq!(pm.search_covering(&"10.1.1.1/32".parse()?), vec![&0, &1, &2]);
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "ipnet"))]
+    /// # fn main() {}
+    /// ```
+    pub fn search_covering<'a>(&'a self, prefix: &P) -> Vec<&'a T> {
+        let mut idx = 0;
+        let mut result = Vec::new();
+        loop {
+            match self.get_direction(idx, prefix) {
+                Direction::Enter { next, .. } => {
+                    if let Some(value) = self.table[next].value.as_ref() {
+                        result.push(value);
+                    }
+                    idx = next
+                },
+                _ => return result,
+            }
+        }
+    }
+
     /// Get a value of an element by using shortest prefix matching.
     ///
     /// ```


### PR DESCRIPTION
Thank you for creating such a convenient and useful Rust library! I am doing research about BGP routing, and previously, I implemented an algorithm using the [py-radix](https://pypi.org/project/py-radix/) library in Python, but it had serious efficiency issues (the program needed to process millions of prefixes and ASN data and perform complex calculations), so I rewrote it in Rust. Most of the algorithms could find equivalent replacements in `prefix-trie`, which is great. However, a method called `search_covering` from the py-radix library does not have a corresponding implementation in prefix-trie, so I would like to add it. This method would return a vec of all nodes that cover a given prefix.