### PR TITLE
Implement the cover of prefixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix-trie"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tiborschneider/prefix-trie"

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -582,6 +582,9 @@ where
     /// Iterate over all entries in the map that covers the given `prefix` (including `prefix`
     /// itself if that is present in the map). The returned iterator yields `(&'a P, &'a T)`.
     ///
+    /// The iterator will always yield elements ordered by their prefix length, i.e., their depth in
+    /// the tree.
+    ///
     /// ```
     /// # use prefix_trie::*;
     /// # #[cfg(feature = "ipnet")]
@@ -632,6 +635,9 @@ where
     /// Iterate over all keys (prefixes) in the map that covers the given `prefix` (including
     /// `prefix` itself if that is present in the map). The returned iterator yields `&'a P`.
     ///
+    /// The iterator will always yield elements ordered by their prefix length, i.e., their depth in
+    /// the tree.
+    ///
     /// ```
     /// # use prefix_trie::*;
     /// # #[cfg(feature = "ipnet")]
@@ -662,6 +668,9 @@ where
 
     /// Iterate over all values in the map that covers the given `prefix` (including `prefix`
     /// itself if that is present in the map). The returned iterator yields `&'a T`.
+    ///
+    /// The iterator will always yield elements ordered by their prefix length, i.e., their depth in
+    /// the tree.
     ///
     /// ```
     /// # use prefix_trie::*;

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -348,6 +348,9 @@ impl<P: Prefix> PrefixSet<P> {
     /// Iterate over all prefixes in the set that covers the given `prefix` (including `prefix`
     /// itself if that is present in the set). The returned iterator yields `&'a P`.
     ///
+    /// The iterator will always yield elements ordered by their prefix length, i.e., their depth in
+    /// the tree.
+    ///
     /// ```
     /// # use prefix_trie::*;
     /// # #[cfg(feature = "ipnet")]


### PR DESCRIPTION
This PR implements algorithms to obtain a cover of a prefix, that is, the sequence of all prefixes (and / or their values) that entails (covers) a given prefix.

This is a new attempt at implementing #4

**TODO**
- [x] Implement the algorithm
- [x] Fix the bug that the root node is also included
- [x] Add documentation tests
- [x] Document the order of elements