### PR TITLE
Track prefix lifetime separately for Cover

### DIFF
--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -524,13 +524,13 @@ where
 
 /// An iterator that yields all items in a `PrefixMap` that covers a given prefix (including the
 /// prefix itself if preseint). See [`PrefixMap::cover`] for how to create this iterator.
-pub struct Cover<'a, P, T> {
+pub struct Cover<'a, 'p, P, T> {
     pub(super) table: &'a Table<P, T>,
     pub(super) idx: Option<usize>,
-    pub(super) prefix: P,
+    pub(super) prefix: &'p P,
 }
 
-impl<'a, P, T> Iterator for Cover<'a, P, T>
+impl<'a, P, T> Iterator for Cover<'a, '_, P, T>
 where
     P: Prefix,
 {
@@ -550,7 +550,7 @@ where
 
         loop {
             let map::Direction::Enter { next, .. } =
-                self.table.get_direction(self.idx.unwrap(), &self.prefix)
+                self.table.get_direction(self.idx.unwrap(), self.prefix)
             else {
                 return None;
             };
@@ -566,9 +566,9 @@ where
 /// An iterator that yields all keys (prefixes) in a `PrefixMap` that covers a given prefix
 /// (including the prefix itself if preseint). See [`PrefixMap::cover_keys`] for how to create this
 /// iterator.
-pub struct CoverKeys<'a, P, T>(pub(super) Cover<'a, P, T>);
+pub struct CoverKeys<'a, 'p, P, T>(pub(super) Cover<'a, 'p, P, T>);
 
-impl<'a, P, T> Iterator for CoverKeys<'a, P, T>
+impl<'a, P, T> Iterator for CoverKeys<'a, '_, P, T>
 where
     P: Prefix,
 {
@@ -581,9 +581,9 @@ where
 
 /// An iterator that yields all values in a `PrefixMap` that covers a given prefix (including the
 /// prefix itself if preseint). See [`PrefixMap::cover_values`] for how to create this iterator.
-pub struct CoverValues<'a, P, T>(pub(super) Cover<'a, P, T>);
+pub struct CoverValues<'a, 'p, P, T>(pub(super) Cover<'a, 'p, P, T>);
 
-impl<'a, P, T> Iterator for CoverValues<'a, P, T>
+impl<'a, P, T> Iterator for CoverValues<'a, '_, P, T>
 where
     P: Prefix,
 {

--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -527,7 +527,7 @@ where
 pub struct Cover<'a, P, T> {
     pub(super) table: &'a Table<P, T>,
     pub(super) idx: Option<usize>,
-    pub(super) prefix: &'a P,
+    pub(super) prefix: P,
 }
 
 impl<'a, P, T> Iterator for Cover<'a, P, T>
@@ -550,7 +550,7 @@ where
 
         loop {
             let map::Direction::Enter { next, .. } =
-                self.table.get_direction(self.idx.unwrap(), self.prefix)
+                self.table.get_direction(self.idx.unwrap(), &self.prefix)
             else {
                 return None;
             };

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -647,7 +647,7 @@ where
     /// pm.insert("10.1.1.0/25".parse()?, 4); // more specific prefixes are not covered
     /// pm.insert("11.0.0.0/8".parse()?, 5);  // Branch points that don't contain values are skipped
     /// assert_eq!(
-    ///     pm.cover(&p2).collect::<Vec<_>>(),
+    ///     pm.cover(p2).collect::<Vec<_>>(),
     ///     vec![(&p0, &0), (&p1, &1), (&p2, &2)]
     /// );
     /// # Ok(())
@@ -665,13 +665,13 @@ where
     /// let mut pm: PrefixMap<ipnet::Ipv4Net, _> = PrefixMap::new();
     /// let root = "0.0.0.0/0".parse()?;
     /// pm.insert(root, 0);
-    /// assert_eq!(pm.cover(&"10.0.0.0/8".parse()?).collect::<Vec<_>>(), vec![(&root, &0)]);
+    /// assert_eq!(pm.cover("10.0.0.0/8".parse()?).collect::<Vec<_>>(), vec![(&root, &0)]);
     /// # Ok(())
     /// # }
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn cover<'a>(&'a self, prefix: &'a P) -> Cover<'a, P, T> {
+    pub fn cover(&self, prefix: P) -> Cover<'_, P, T> {
         Cover {
             table: &self.table,
             idx: None,
@@ -699,13 +699,13 @@ where
     /// pm.insert("10.1.2.0/24".parse()?, 3); // disjoint prefixes are not covered
     /// pm.insert("10.1.1.0/25".parse()?, 4); // more specific prefixes are not covered
     /// pm.insert("11.0.0.0/8".parse()?, 5);  // Branch points that don't contain values are skipped
-    /// assert_eq!(pm.cover_keys(&p2).collect::<Vec<_>>(), vec![&p0, &p1, &p2]);
+    /// assert_eq!(pm.cover_keys(p2).collect::<Vec<_>>(), vec![&p0, &p1, &p2]);
     /// # Ok(())
     /// # }
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn cover_keys<'a>(&'a self, prefix: &'a P) -> CoverKeys<'a, P, T> {
+    pub fn cover_keys(&self, prefix: P) -> CoverKeys<'_, P, T> {
         CoverKeys(Cover {
             table: &self.table,
             idx: None,
@@ -733,13 +733,13 @@ where
     /// pm.insert("10.1.2.0/24".parse()?, 3); // disjoint prefixes are not covered
     /// pm.insert("10.1.1.0/25".parse()?, 4); // more specific prefixes are not covered
     /// pm.insert("11.0.0.0/8".parse()?, 5);  // Branch points that don't contain values are skipped
-    /// assert_eq!(pm.cover_values(&p2).collect::<Vec<_>>(), vec![&0, &1, &2]);
+    /// assert_eq!(pm.cover_values(p2).collect::<Vec<_>>(), vec![&0, &1, &2]);
     /// # Ok(())
     /// # }
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn cover_values<'a>(&'a self, prefix: &'a P) -> CoverValues<'a, P, T> {
+    pub fn cover_values(&self, prefix: P) -> CoverValues<'_, P, T> {
         CoverValues(Cover {
             table: &self.table,
             idx: None,

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -647,7 +647,7 @@ where
     /// pm.insert("10.1.1.0/25".parse()?, 4); // more specific prefixes are not covered
     /// pm.insert("11.0.0.0/8".parse()?, 5);  // Branch points that don't contain values are skipped
     /// assert_eq!(
-    ///     pm.cover(p2).collect::<Vec<_>>(),
+    ///     pm.cover(&p2).collect::<Vec<_>>(),
     ///     vec![(&p0, &0), (&p1, &1), (&p2, &2)]
     /// );
     /// # Ok(())
@@ -665,13 +665,13 @@ where
     /// let mut pm: PrefixMap<ipnet::Ipv4Net, _> = PrefixMap::new();
     /// let root = "0.0.0.0/0".parse()?;
     /// pm.insert(root, 0);
-    /// assert_eq!(pm.cover("10.0.0.0/8".parse()?).collect::<Vec<_>>(), vec![(&root, &0)]);
+    /// assert_eq!(pm.cover(&"10.0.0.0/8".parse()?).collect::<Vec<_>>(), vec![(&root, &0)]);
     /// # Ok(())
     /// # }
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn cover(&self, prefix: P) -> Cover<'_, P, T> {
+    pub fn cover<'a, 'p>(&'a self, prefix: &'p P) -> Cover<'a, 'p, P, T> {
         Cover {
             table: &self.table,
             idx: None,
@@ -699,13 +699,13 @@ where
     /// pm.insert("10.1.2.0/24".parse()?, 3); // disjoint prefixes are not covered
     /// pm.insert("10.1.1.0/25".parse()?, 4); // more specific prefixes are not covered
     /// pm.insert("11.0.0.0/8".parse()?, 5);  // Branch points that don't contain values are skipped
-    /// assert_eq!(pm.cover_keys(p2).collect::<Vec<_>>(), vec![&p0, &p1, &p2]);
+    /// assert_eq!(pm.cover_keys(&p2).collect::<Vec<_>>(), vec![&p0, &p1, &p2]);
     /// # Ok(())
     /// # }
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn cover_keys(&self, prefix: P) -> CoverKeys<'_, P, T> {
+    pub fn cover_keys<'a, 'p>(&'a self, prefix: &'p P) -> CoverKeys<'a, 'p, P, T> {
         CoverKeys(Cover {
             table: &self.table,
             idx: None,
@@ -733,13 +733,13 @@ where
     /// pm.insert("10.1.2.0/24".parse()?, 3); // disjoint prefixes are not covered
     /// pm.insert("10.1.1.0/25".parse()?, 4); // more specific prefixes are not covered
     /// pm.insert("11.0.0.0/8".parse()?, 5);  // Branch points that don't contain values are skipped
-    /// assert_eq!(pm.cover_values(p2).collect::<Vec<_>>(), vec![&0, &1, &2]);
+    /// assert_eq!(pm.cover_values(&p2).collect::<Vec<_>>(), vec![&0, &1, &2]);
     /// # Ok(())
     /// # }
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn cover_values(&self, prefix: P) -> CoverValues<'_, P, T> {
+    pub fn cover_values<'a, 'p>(&'a self, prefix: &'p P) -> CoverValues<'a, 'p, P, T> {
         CoverValues(Cover {
             table: &self.table,
             idx: None,

--- a/src/set.rs
+++ b/src/set.rs
@@ -319,13 +319,13 @@ impl<P: Prefix> PrefixSet<P> {
     /// set.insert("10.1.2.0/24".parse()?); // disjoint prefixes are not covered
     /// set.insert("10.1.1.0/25".parse()?); // more specific prefixes are not covered
     /// set.insert("11.0.0.0/8".parse()?);  // Branch points that don't contain values are skipped
-    /// assert_eq!(set.cover(&p2).collect::<Vec<_>>(), vec![&p0, &p1, &p2]);
+    /// assert_eq!(set.cover(p2).collect::<Vec<_>>(), vec![&p0, &p1, &p2]);
     /// # Ok(())
     /// # }
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn cover<'a>(&'a self, prefix: &'a P) -> CoverKeys<'a, P, ()> {
+    pub fn cover(&self, prefix: P) -> CoverKeys<'_, P, ()> {
         self.0.cover_keys(prefix)
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -319,13 +319,13 @@ impl<P: Prefix> PrefixSet<P> {
     /// set.insert("10.1.2.0/24".parse()?); // disjoint prefixes are not covered
     /// set.insert("10.1.1.0/25".parse()?); // more specific prefixes are not covered
     /// set.insert("11.0.0.0/8".parse()?);  // Branch points that don't contain values are skipped
-    /// assert_eq!(set.cover(p2).collect::<Vec<_>>(), vec![&p0, &p1, &p2]);
+    /// assert_eq!(set.cover(&p2).collect::<Vec<_>>(), vec![&p0, &p1, &p2]);
     /// # Ok(())
     /// # }
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn cover(&self, prefix: P) -> CoverKeys<'_, P, ()> {
+    pub fn cover<'a, 'p>(&'a self, prefix: &'p P) -> CoverKeys<'a, 'p, P, ()> {
         self.0.cover_keys(prefix)
     }
 }


### PR DESCRIPTION
I know that this would be a breaking change, but I imagine that most users of this crate are using prefix types which are `Copy` anyone, such that it would be a trivial change. I also note that the `Iter` struct (returned by the `children` method) takes an owned prefix already.

I hope that you will consider my use case which fails to compile before this change:

```rust
use ipnet::{IpNet, Ipv4Net, Ipv6Net};
use prefix_trie::PrefixMap;

struct DualStackMap<V> {
    v4: PrefixMap<Ipv4Net, V>,
    v6: PrefixMap<Ipv6Net, V>,
}

impl<V> DualStackMap<V> {
    fn cover_values(&self, prefix: IpNet) -> Vec<&V> {
        match prefix {
            IpNet::V4(p) => self.v4.cover_values(&p).collect(),
            IpNet::V6(p) => self.v6.cover_values(&p).collect(),
        }
    }
}
```

It fails to compile because within the match, a reference to the inner `p` is created on the spot, but that reference does not last as long as the `Vec<&V>` returned by the function. I can make my function take `&IpNet`, but the temporary reference problem then moves to whichever function is calling this, severely limiting the usefulness of the actual impl function. In the case of the application I'm working on, in order to work around this my values have to be `Arc<Mutex<V>>` or similar, with this function returning `Vec<V>` and doing some cloning instead.