### PR TITLE
Implement PartialEq for Views

### DIFF
--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -894,13 +894,16 @@ where
     }
 }
 
-impl<P, T> PartialEq for PrefixMap<P, T>
+impl<P, L, Rhs> PartialEq<Rhs> for PrefixMap<P, L>
 where
     P: Prefix + PartialEq,
-    T: PartialEq,
+    L: PartialEq<Rhs::T>,
+    Rhs: crate::AsView<P = P>,
 {
-    fn eq(&self, other: &Self) -> bool {
-        self.iter().zip(other.iter()).all(|(a, b)| a == b)
+    fn eq(&self, other: &Rhs) -> bool {
+        self.iter()
+            .zip(other.view().iter())
+            .all(|((lp, lt), (rp, rt))| lt == rt && lp == rp)
     }
 }
 

--- a/src/trieview/difference.rs
+++ b/src/trieview/difference.rs
@@ -132,7 +132,7 @@ where
     /// let sub_a = map_a.view_at(net!("192.168.0.0/22")).unwrap();
     /// let sub_b = map_b.view_at(net!("192.168.0.0/22")).unwrap();
     /// assert_eq!(
-    ///     sub_a.difference(sub_b).collect::<Vec<_>>(),
+    ///     sub_a.difference(&sub_b).collect::<Vec<_>>(),
     ///     vec![
     ///         DifferenceItem { prefix: &net!("192.168.0.0/24"), value: &3, right: Some((&net!("192.168.0.0/23"), &"c"))},
     ///         DifferenceItem { prefix: &net!("192.168.2.0/23"), value: &4, right: Some((&net!("192.168.0.0/22"), &"b"))},
@@ -140,7 +140,7 @@ where
     /// );
     /// # }
     /// ```
-    pub fn difference<R>(&self, other: impl AsView<'a, P, R>) -> Difference<'a, P, L, R> {
+    pub fn difference<R>(&self, other: &'a impl AsView<P = P, T = R>) -> Difference<'a, P, L, R> {
         let other = other.view();
         Difference {
             table_l: self.table,
@@ -186,7 +186,7 @@ where
     /// ```
     pub fn covering_difference<R>(
         &self,
-        other: impl AsView<'a, P, R>,
+        other: &'a impl AsView<P = P, T = R>,
     ) -> CoveringDifference<'a, P, L, R> {
         let other = other.view();
         CoveringDifference {
@@ -237,7 +237,7 @@ where
     ///
     /// let mut sub_a = map_a.view_mut_at(net!("192.168.0.0/22")).unwrap();
     /// let sub_b = map_b.view_at(net!("192.168.0.0/22")).unwrap();
-    /// sub_a.difference_mut(sub_b).for_each(|x| *x.value += 10);
+    /// sub_a.difference_mut(&sub_b).for_each(|x| *x.value += 10);
     ///
     /// assert_eq!(
     ///     map_a.into_iter().collect::<Vec<_>>(),
@@ -250,10 +250,10 @@ where
     /// );
     /// # }
     /// ```
-    pub fn difference_mut<'b, R>(
-        &'b mut self,
-        other: impl AsView<'b, P, R>,
-    ) -> DifferenceMut<'b, P, L, R> {
+    pub fn difference_mut<'a, R>(
+        &'a mut self,
+        other: &'a impl AsView<P = P, T = R>,
+    ) -> DifferenceMut<'a, P, L, R> {
         let other = other.view();
         let nodes = extend_lpm(
             other.table,
@@ -304,10 +304,10 @@ where
     /// );
     /// # }
     /// ```
-    pub fn covering_difference_mut<'b, R>(
-        &'b mut self,
-        other: impl AsView<'b, P, R>,
-    ) -> CoveringDifferenceMut<'b, P, L, R> {
+    pub fn covering_difference_mut<'a, R>(
+        &'a mut self,
+        other: &'a impl AsView<P = P, T = R>,
+    ) -> CoveringDifferenceMut<'a, P, L, R> {
         let other = other.view();
         let nodes = next_indices(
             self.table,

--- a/src/trieview/intersection.rs
+++ b/src/trieview/intersection.rs
@@ -71,7 +71,7 @@ where
     /// let sub_a = map_a.view_at(net!("192.168.0.0/22")).unwrap();
     /// let sub_b = map_b.view_at(net!("192.168.0.0/22")).unwrap();
     /// assert_eq!(
-    ///     sub_a.intersection(sub_b).collect::<Vec<_>>(),
+    ///     sub_a.intersection(&sub_b).collect::<Vec<_>>(),
     ///     vec![
     ///         (&net!("192.168.0.0/22"), &2, &"b"),
     ///         (&net!("192.168.0.0/24"), &3, &"d"),
@@ -79,7 +79,10 @@ where
     /// );
     /// # }
     /// ```
-    pub fn intersection<R>(&self, other: impl AsView<'a, P, R>) -> Intersection<'a, P, L, R> {
+    pub fn intersection<R>(
+        &self,
+        other: &'a impl AsView<P = P, T = R>,
+    ) -> Intersection<'a, P, L, R> {
         let other = other.view();
         Intersection {
             table_l: self.table,

--- a/src/trieview/mod.rs
+++ b/src/trieview/mod.rs
@@ -163,6 +163,26 @@ impl<P: std::fmt::Debug, T: std::fmt::Debug> std::fmt::Debug for TrieView<'_, P,
     }
 }
 
+impl<P, L, Rhs> PartialEq<Rhs> for TrieView<'_, P, L>
+where
+    P: Prefix + PartialEq,
+    L: PartialEq<Rhs::T>,
+    Rhs: crate::AsView<P = P>,
+{
+    fn eq(&self, other: &Rhs) -> bool {
+        self.iter()
+            .zip(other.view().iter())
+            .all(|((lp, lt), (rp, rt))| lt == rt && lp == rp)
+    }
+}
+
+impl<P, T> Eq for TrieView<'_, P, T>
+where
+    P: Prefix + Eq + Clone,
+    T: Eq,
+{
+}
+
 impl<'a, P, T> TrieView<'a, P, T>
 where
     P: Prefix,
@@ -712,6 +732,27 @@ impl<P: std::fmt::Debug, T: std::fmt::Debug> std::fmt::Debug for TrieViewMut<'_,
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("ViewMut").field(self.prefix()).finish()
     }
+}
+
+impl<P, L, Rhs> PartialEq<Rhs> for TrieViewMut<'_, P, L>
+where
+    P: Prefix + PartialEq + Clone,
+    L: PartialEq<Rhs::T>,
+    Rhs: crate::AsView<P = P>,
+{
+    fn eq(&self, other: &Rhs) -> bool {
+        self.view()
+            .iter()
+            .zip(other.view().iter())
+            .all(|((lp, lt), (rp, rt))| lt == rt && lp == rp)
+    }
+}
+
+impl<P, T> Eq for TrieViewMut<'_, P, T>
+where
+    P: Prefix + Eq + Clone,
+    T: Eq,
+{
 }
 
 impl<P, T> TrieViewMut<'_, P, T>

--- a/src/trieview/mod.rs
+++ b/src/trieview/mod.rs
@@ -11,25 +11,45 @@ use crate::{
 };
 
 /// A trait for creating a [`TrieView`] of `self`.
-pub trait AsView<'a, P: Prefix, T>: Sized {
+pub trait AsView: Sized {
+    /// The prefix type of the returned view
+    type P: Prefix;
+    /// The value type of the returned view
+    type T;
+
     /// Get a TrieView rooted at the origin (referencing the entire trie).
-    fn view(self) -> TrieView<'a, P, T>;
+    fn view(&self) -> TrieView<'_, Self::P, Self::T>;
 
     /// Get a TrieView rooted at the given `prefix`. If that `prefix` is not part of the trie, `None`
     /// is returned. Calling this function is identical to `self.view().find(prefix)`.
-    fn view_at(self, prefix: P) -> Option<TrieView<'a, P, T>> {
+    fn view_at(&self, prefix: Self::P) -> Option<TrieView<'_, Self::P, Self::T>> {
         self.view().find(prefix)
     }
 }
 
-impl<'a, P: Prefix, T> AsView<'a, P, T> for TrieView<'a, P, T> {
-    fn view(self) -> TrieView<'a, P, T> {
-        self
+impl<'a, P: Prefix + Clone, T> AsView for TrieView<'a, P, T> {
+    type P = P;
+    type T = T;
+
+    fn view(&self) -> TrieView<'a, P, T> {
+        self.clone()
     }
 }
 
-impl<'b: 'a, 'a, P: Prefix + Clone, T> AsView<'a, P, T> for &'a TrieViewMut<'b, P, T> {
-    fn view(self) -> TrieView<'a, P, T> {
+impl<'a, P: Prefix + Clone, T> AsView for &TrieView<'a, P, T> {
+    type P = P;
+    type T = T;
+
+    fn view(&self) -> TrieView<'a, P, T> {
+        (*self).clone()
+    }
+}
+
+impl<'b: 'a, 'a, P: Prefix + Clone, T> AsView for &'a TrieViewMut<'b, P, T> {
+    type P = P;
+    type T = T;
+
+    fn view(&self) -> TrieView<'a, P, T> {
         TrieView {
             table: self.table,
             loc: self.loc.clone(),
@@ -37,8 +57,23 @@ impl<'b: 'a, 'a, P: Prefix + Clone, T> AsView<'a, P, T> for &'a TrieViewMut<'b, 
     }
 }
 
-impl<'a, P: Prefix, T> AsView<'a, P, T> for &'a PrefixMap<P, T> {
-    fn view(self) -> TrieView<'a, P, T> {
+impl<P: Prefix + Clone, T> AsView for TrieViewMut<'_, P, T> {
+    type P = P;
+    type T = T;
+
+    fn view(&self) -> TrieView<'_, P, T> {
+        TrieView {
+            table: self.table,
+            loc: self.loc.clone(),
+        }
+    }
+}
+
+impl<P: Prefix, T> AsView for PrefixMap<P, T> {
+    type P = P;
+    type T = T;
+
+    fn view(&self) -> TrieView<'_, P, T> {
         TrieView {
             table: &self.table,
             loc: ViewLoc::Node(0),
@@ -46,8 +81,35 @@ impl<'a, P: Prefix, T> AsView<'a, P, T> for &'a PrefixMap<P, T> {
     }
 }
 
-impl<'a, P: Prefix> AsView<'a, P, ()> for &'a PrefixSet<P> {
-    fn view(self) -> TrieView<'a, P, ()> {
+impl<'a, P: Prefix, T> AsView for &'a PrefixMap<P, T> {
+    type P = P;
+    type T = T;
+
+    fn view<'b>(&'b self) -> TrieView<'a, P, T> {
+        TrieView {
+            table: &self.table,
+            loc: ViewLoc::Node(0),
+        }
+    }
+}
+
+impl<P: Prefix> AsView for PrefixSet<P> {
+    type P = P;
+    type T = ();
+
+    fn view(&self) -> TrieView<'_, P, ()> {
+        TrieView {
+            table: &self.0.table,
+            loc: ViewLoc::Node(0),
+        }
+    }
+}
+
+impl<'a, P: Prefix> AsView for &'a PrefixSet<P> {
+    type P = P;
+    type T = ();
+
+    fn view<'b>(&'b self) -> TrieView<'a, P, ()> {
         TrieView {
             table: &self.0.table,
             loc: ViewLoc::Node(0),

--- a/src/trieview/union.rs
+++ b/src/trieview/union.rs
@@ -185,7 +185,7 @@ where
     /// );
     /// # }
     /// ```
-    pub fn union<R>(&self, other: impl AsView<'a, P, R>) -> Union<'a, P, L, R> {
+    pub fn union<R>(&self, other: &'a impl AsView<P = P, T = R>) -> Union<'a, P, L, R> {
         let other = other.view();
         Union {
             table_l: self.table,


### PR DESCRIPTION
1. Redefine `AsView` using associate types for `P` and `T`, and define the function `view` as taking a reference to `self`.
2. Implement `AsView` for types and their references.
3. Implement `PartialEq` for an `Rhs` that implements `AsView` for any `AsView::T` that is comparable

Unfortunately, this is a breaking change, as the simultaneous tree traversal methods require passing in an `AsView` as reference. I still have to investigate this.

#16 