### PR TITLE
Fix memory leak during parent node collapse (Closes #23)

### DIFF
--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -1111,11 +1111,15 @@ where
                 // current node. but only do that if the grandparent is something.
                 if let Some(grp) = grp {
                     if self.table[par].value.is_none() {
+                        let par_idx = NonZeroUsize::new(par)
+                            .expect("Grandparent is set, so parent must be non-root");
                         if let Some(sibling) = self.table.get_child(par, !par_right) {
                             self.table.set_child(grp, sibling, grp_right);
+                            self.free.push(par_idx);
                             return (value, true);
                         } else {
                             self.table.clear_child(grp, grp_right);
+                            self.free.push(par_idx);
                         }
                     }
                 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -707,6 +707,39 @@ mod t {
         );
     }
 
+    #[test]
+    fn regression_free_list_on_parent_collapse<P: Prefix + Copy + PartialEq>() {
+        // Regression test for issue #23: Memory leak when removing leaf nodes
+
+        let mut pm = Map::<P>::new();
+
+        // a custom tree to force a valueless branch node
+        // root -> branch(10.0.0.0/8) -> [leaf1(10.0.0.0/10), leaf2(10.128.0.0/10)]
+        pm.insert(ip("10.0.0.0/10"), 1);
+        pm.insert(ip("10.128.0.0/10"), 2);
+
+        // the initial size of the underlying memory vector
+        let initial_table_size = pm.table.as_ref().len();
+        assert_eq!(initial_table_size, 4); // including the root and the branch nodes
+
+        // Remove a leaf, which triggers the parent branch to collapse.
+        assert_eq!(pm.remove(&ip("10.128.0.0/10")), Some(2));
+
+        // Cycle insert and remove multiple times.
+        for i in 3..=20 {
+            pm.insert(ip("10.128.0.0/10"), i);
+            pm.remove(&ip("10.128.0.0/10"));
+        }
+
+        // Final verification: the memory footprint should not have grown.
+        let final_table_size = pm.table.as_ref().len();
+        assert_eq!(
+            final_table_size, initial_table_size,
+            "Memory Leak Detected! The internal table grew from {} to {} nodes. Collapsed branch nodes are not being added to the free list.",
+            initial_table_size, final_table_size
+        );
+    }
+
     #[instantiate_tests(<(u32, u8)>)]
     mod raw32 {}
 


### PR DESCRIPTION
Description
This PR fixes the memory leak identified in #23 where valueless parent nodes were not added to the free list during tree collapsing, causing unbounded growth of the table vector.

Changes:

Added self.free.push(par_idx) to both branches of the grandparent collapse logic in _remove_node.

Added a comprehensive regression test regression_free_list_on_parent_collapse, that asserts the table size remains stable after multiple insert/remove cycles.

Note -- without this fix, if we run this test, then we can see a leak in memory.

Closes #23