### PR TITLE
Raise minimum dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ ipnet = ["dep:ipnet"]
 cidr = ["dep:cidr"]
 
 [dependencies]
-ipnet = { version = "2", optional = true}
+ipnet = { version = "2.3.0", optional = true}
 ipnetwork = { version = "0.20", optional = true }
 cidr = { version = "0.3", optional = true }
-num-traits = "0.2"
+num-traits = "0.2.4"
 serde = { version = "1", optional = true}
 either = "1"
 


### PR DESCRIPTION
This raises minimum version constraints on two dependencies to the minimum needed for compilation to work. With this, [`cargo minimal-versions check`](https://github.com/taiki-e/cargo-minimal-versions) passes. `ipnet` needs to be bumped up for a [`Default` implementation](https://github.com/krisprice/ipnet/blob/master/RELEASES.md#version-230-2020-03-15), and `num-traits` needs to be bumped up for [`u128` implementations](https://github.com/rust-num/num-traits/blob/master/RELEASES.md#release-024-2018-05-11) used by `ipnet`.