### PR TITLE
do not drop trivial values

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -373,7 +373,9 @@ impl<T> Default for Table<T> {
 
 impl<T> Drop for Table<T> {
     fn drop(&mut self) {
-        self.drop_values();
+        if std::mem::needs_drop::<T>() {
+            self.drop_values();
+        }
     }
 }
 


### PR DESCRIPTION
Skip dropping items when T does not need drop

This optimisation that showed up while profiling a loop where I created and filled a `PrefixMap` a few hundred times. A similar optimisation is likely possible in `clear()` or the allocator
, but I don't have enough understanding of the code to make that change safely.

This made a ~15% change in the attached benchmark case that I used for sampling. 
[profile_bgp_create_random.rs.zip](https://github.com/user-attachments/files/27812011/profile_bgp_create_random.rs.zip)