### PR TITLE
feat: add address_count() to PrefixMap, PrefixSet, and JointPrefixMap

### DIFF
--- a/src/fuzzing/aggregate.rs
+++ b/src/fuzzing/aggregate.rs
@@ -93,6 +93,7 @@ fn _aggregate_set(prefixes: Vec<TestPrefix>) -> bool {
     // The covered address space must be preserved exactly, and the cached `len()` must stay in sync
     // with the actual element count (it is maintained manually via the aggregation's count delta).
     original_space == aggregated_space
+        && original.address_count() == aggregated.address_count()
         && aggregated.len() == aggregated.iter().count()
         && aggregated.0.check_memory_alloc()
         && aggregated == double_agg
@@ -165,6 +166,7 @@ fn _aggregate_consistent_map(entries: Vec<(TestPrefix, u8)>) -> bool {
 
     // `get_lpm` is identical for every address, and `aggregate_consistent` is idempotent.
     original_lpm == aggregated_lpm
+        && original.address_count() == aggregated.address_count()
         && is_subset
         && aggregated.len() == aggregated.iter().count()
         && aggregated.check_memory_alloc()
@@ -195,6 +197,7 @@ fn _aggregate_consistent_set(prefixes: Vec<TestPrefix>) -> bool {
         .all(|p| original.get_lpm(p).is_some() == aggregated.get_lpm(p).is_some());
 
     original_space == aggregated_space
+        && original.address_count() == aggregated.address_count()
         && is_subset
         && lpm_presence_preserved
         && aggregated.len() == aggregated.iter().count()
@@ -219,6 +222,7 @@ fn _aggregate_map(entries: Vec<(TestPrefix, u8)>) -> bool {
     // Equal range-maps mean `get_lpm` matches for every address, covered set included: a newly
     // covered hole would appear as an extra range and fail the comparison.
     original_lpm == aggregated_lpm
+        && original.address_count() == aggregated.address_count()
         && aggregated.len() == aggregated.iter().count()
         && aggregated.check_memory_alloc()
         && aggregated == twice

--- a/src/joint/map/mod.rs
+++ b/src/joint/map/mod.rs
@@ -91,6 +91,46 @@ impl<P: JointPrefix, T> JointPrefixMap<P, T> {
         self.len() == 0
     }
 
+    /// Count the number of unique addresses covered by all prefixes, split by address family.
+    ///
+    /// Each table is first aggregated, so overlapping prefixes are counted only once.
+    /// Returns `None` for an address family if its entire space is covered
+    /// (e.g., `::/0` for IPv6), since 2<sup>num_bits</sup>
+    /// cannot be represented in a `u128`.
+    ///
+    /// ```
+    /// # use prefix_trie::joint::*;
+    /// # #[cfg(feature = "ipnet")]
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut pm: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+    /// pm.insert("192.0.2.0/24".parse()?, 1);
+    /// pm.insert("2001:db8::/48".parse()?, 2);
+    /// let count = pm.address_count();
+    /// assert_eq!(count.0, Some(256));
+    /// assert_eq!(count.1, Some(1u128 << 80));
+    ///
+    /// // Full IPv4 space (2^32 fits in u128)
+    /// let mut full: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+    /// full.insert("0.0.0.0/0".parse()?, 1);
+    /// let count = full.address_count();
+    /// assert_eq!(count.0, Some(1u128 << 32));
+    /// assert_eq!(count.1, Some(0));
+    ///
+    /// // Full IPv6 space (2^128 overflows u128)
+    /// let mut full6: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+    /// full6.insert("::/0".parse()?, 1);
+    /// let count = full6.address_count();
+    /// assert_eq!(count.0, Some(0));
+    /// assert_eq!(count.1, None);
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "ipnet"))]
+    /// # fn main() {}
+    /// ```
+    pub fn address_count(&self) -> (Option<u128>, Option<u128>) {
+        (self.t1.address_count(), self.t2.address_count())
+    }
+
     /// Get the value of an element by matching exactly on the prefix.
     ///
     /// ```

--- a/src/joint/map/mod.rs
+++ b/src/joint/map/mod.rs
@@ -1,7 +1,7 @@
 //! Module that defines the JointPrefixMap
 
 use super::JointPrefix;
-use crate::{AsView, PrefixMap, TrieView};
+use crate::{AsView, Prefix, PrefixMap, TrieView};
 #[cfg(test)]
 #[cfg(feature = "ipnet")]
 mod test;
@@ -93,10 +93,9 @@ impl<P: JointPrefix, T> JointPrefixMap<P, T> {
 
     /// Count the number of unique addresses covered by all prefixes, split by address family.
     ///
-    /// Each table is first aggregated, so overlapping prefixes are counted only once.
-    /// Returns `None` for an address family if its entire space is covered
-    /// (e.g., `::/0` for IPv6), since 2<sup>num_bits</sup>
-    /// cannot be represented in a `u128`.
+    /// Each table is traversed without mutation, so overlapping prefixes are counted only once.
+    /// Returns `None` for an address family if its count cannot be represented in that family's
+    /// address representation, such as a fully covered address space.
     ///
     /// ```
     /// # use prefix_trie::joint::*;
@@ -109,14 +108,13 @@ impl<P: JointPrefix, T> JointPrefixMap<P, T> {
     /// assert_eq!(count.0, Some(256));
     /// assert_eq!(count.1, Some(1u128 << 80));
     ///
-    /// // Full IPv4 space (2^32 fits in u128)
+    /// // Full address spaces cannot be represented in their address type.
     /// let mut full: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
     /// full.insert("0.0.0.0/0".parse()?, 1);
     /// let count = full.address_count();
-    /// assert_eq!(count.0, Some(1u128 << 32));
+    /// assert_eq!(count.0, None);
     /// assert_eq!(count.1, Some(0));
     ///
-    /// // Full IPv6 space (2^128 overflows u128)
     /// let mut full6: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
     /// full6.insert("::/0".parse()?, 1);
     /// let count = full6.address_count();
@@ -127,7 +125,8 @@ impl<P: JointPrefix, T> JointPrefixMap<P, T> {
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn address_count(&self) -> (Option<u128>, Option<u128>) {
+    #[allow(clippy::type_complexity)]
+    pub fn address_count(&self) -> (Option<<P::P1 as Prefix>::R>, Option<<P::P2 as Prefix>::R>) {
         (self.t1.address_count(), self.t2.address_count())
     }
 

--- a/src/joint/set.rs
+++ b/src/joint/set.rs
@@ -2,7 +2,7 @@
 //! [`super::JointPrefixMap`].
 
 use crate::PrefixSet;
-use crate::{AsView, TrieView};
+use crate::{AsView, Prefix, TrieView};
 use either::{Left, Right};
 
 use super::{map::CoverKeys, JointPrefix};
@@ -81,8 +81,8 @@ impl<P: JointPrefix> JointPrefixSet<P> {
 
     /// Count the number of unique addresses covered by all prefixes, split by address family.
     ///
-    /// Returns `None` for an address family if its entire space is covered (e.g., `::/0` for
-    /// IPv6), since 2<sup>num_bits</sup> cannot be represented in a `u128`.
+    /// Returns `None` for an address family if its count cannot be represented in that family's
+    /// address representation, such as a fully covered address space.
     ///
     /// ```
     /// # use prefix_trie::joint::*;
@@ -97,7 +97,8 @@ impl<P: JointPrefix> JointPrefixSet<P> {
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn address_count(&self) -> (Option<u128>, Option<u128>) {
+    #[allow(clippy::type_complexity)]
+    pub fn address_count(&self) -> (Option<<P::P1 as Prefix>::R>, Option<<P::P2 as Prefix>::R>) {
         (self.t1.address_count(), self.t2.address_count())
     }
 

--- a/src/joint/set.rs
+++ b/src/joint/set.rs
@@ -79,6 +79,28 @@ impl<P: JointPrefix> JointPrefixSet<P> {
         self.len() == 0
     }
 
+    /// Count the number of unique addresses covered by all prefixes, split by address family.
+    ///
+    /// Returns `None` for an address family if its entire space is covered (e.g., `::/0` for
+    /// IPv6), since 2<sup>num_bits</sup> cannot be represented in a `u128`.
+    ///
+    /// ```
+    /// # use prefix_trie::joint::*;
+    /// # #[cfg(feature = "ipnet")]
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut set: JointPrefixSet<ipnet::IpNet> = JointPrefixSet::new();
+    /// set.insert("192.0.2.0/24".parse()?);
+    /// set.insert("2001:db8::/48".parse()?);
+    /// assert_eq!(set.address_count(), (Some(256), Some(1u128 << 80)));
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "ipnet"))]
+    /// # fn main() {}
+    /// ```
+    pub fn address_count(&self) -> (Option<u128>, Option<u128>) {
+        (self.t1.address_count(), self.t2.address_count())
+    }
+
     /// Check whether some prefix is present in the set, without using longest prefix match.
     ///
     /// ```

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -68,9 +68,8 @@ where
     /// Count the number of unique addresses covered by all prefixes in the map.
     ///
     /// A read-only trie traversal skips prefixes covered by a shorter stored prefix, so
-    /// overlapping prefixes are counted only once. Returns `None` if the entire
-    /// address space is covered (e.g., `::/0` for IPv6), since 2<sup>num_bits</sup>
-    /// cannot be represented in a `u128`.
+    /// overlapping prefixes are counted only once. Returns `None` if the count cannot be
+    /// represented in the prefix's address representation, such as a fully covered address space.
     ///
     /// ```
     /// use prefix_trie::PrefixMap;
@@ -83,12 +82,11 @@ where
     /// pm.insert("198.51.100.0/24".parse()?, 3);
     /// assert_eq!(pm.address_count(), Some(512));
     ///
-    /// // Full IPv4 space (2^32 fits in u128)
+    /// // Full address spaces cannot be represented in their address type.
     /// let mut full: PrefixMap<ipnet::Ipv4Net, u32> = PrefixMap::new();
     /// full.insert("0.0.0.0/0".parse()?, 1);
-    /// assert_eq!(full.address_count(), Some(1u128 << 32));
+    /// assert_eq!(full.address_count(), None);
     ///
-    /// // Full IPv6 space (2^128 overflows u128)
     /// let mut full6: PrefixMap<ipnet::Ipv6Net, u32> = PrefixMap::new();
     /// full6.insert("::/0".parse()?, 1);
     /// assert_eq!(full6.address_count(), None);
@@ -97,7 +95,7 @@ where
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn address_count(&self) -> Option<u128> {
+    pub fn address_count(&self) -> Option<P::R> {
         self.table.address_count::<P>()
     }
 

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -67,8 +67,8 @@ where
 
     /// Count the number of unique addresses covered by all prefixes in the map.
     ///
-    /// The map is first aggregated (using [`aggregate_consistent`](Self::aggregate_consistent)),
-    /// so overlapping prefixes are counted only once. Returns `None` if the entire
+    /// A read-only trie traversal skips prefixes covered by a shorter stored prefix, so
+    /// overlapping prefixes are counted only once. Returns `None` if the entire
     /// address space is covered (e.g., `::/0` for IPv6), since 2<sup>num_bits</sup>
     /// cannot be represented in a `u128`.
     ///
@@ -98,26 +98,7 @@ where
     /// # fn main() {}
     /// ```
     pub fn address_count(&self) -> Option<u128> {
-        // Count addresses covered by any prefix, skipping those already covered by a
-        // strictly shorter prefix (via shortest-prefix match).  This avoids cloning or
-        // mutating the map while correctly deduplicating overlapping prefixes.
-        let mut count: u128 = 0;
-        for (prefix, _) in self.iter() {
-            if let Some((spm, _)) = self.get_spm(&prefix) {
-                if spm.prefix_len() < prefix.prefix_len() {
-                    continue;
-                }
-            }
-            let host_bits = P::num_bits() - prefix.prefix_len() as u32;
-            match 1u128
-                .checked_shl(host_bits)
-                .and_then(|c| count.checked_add(c))
-            {
-                Some(v) => count = v,
-                None => return None,
-            }
-        }
-        Some(count)
+        self.table.address_count::<P>()
     }
 
     /// Return a reference to the underlying table (crate-internal use only).

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -65,6 +65,61 @@ where
         self.table.mem_size() + std::mem::size_of::<Self>()
     }
 
+    /// Count the number of unique addresses covered by all prefixes in the map.
+    ///
+    /// The map is first aggregated (using [`aggregate_consistent`](Self::aggregate_consistent)),
+    /// so overlapping prefixes are counted only once. Returns `None` if the entire
+    /// address space is covered (e.g., `::/0` for IPv6), since 2<sup>num_bits</sup>
+    /// cannot be represented in a `u128`.
+    ///
+    /// ```
+    /// use prefix_trie::PrefixMap;
+    ///
+    /// # #[cfg(feature = "ipnet")]
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut pm: PrefixMap<ipnet::Ipv4Net, u32> = PrefixMap::new();
+    /// pm.insert("192.0.2.0/24".parse()?, 1);
+    /// pm.insert("192.0.2.128/25".parse()?, 2); // overlaps, counted once
+    /// pm.insert("198.51.100.0/24".parse()?, 3);
+    /// assert_eq!(pm.address_count(), Some(512));
+    ///
+    /// // Full IPv4 space (2^32 fits in u128)
+    /// let mut full: PrefixMap<ipnet::Ipv4Net, u32> = PrefixMap::new();
+    /// full.insert("0.0.0.0/0".parse()?, 1);
+    /// assert_eq!(full.address_count(), Some(1u128 << 32));
+    ///
+    /// // Full IPv6 space (2^128 overflows u128)
+    /// let mut full6: PrefixMap<ipnet::Ipv6Net, u32> = PrefixMap::new();
+    /// full6.insert("::/0".parse()?, 1);
+    /// assert_eq!(full6.address_count(), None);
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "ipnet"))]
+    /// # fn main() {}
+    /// ```
+    pub fn address_count(&self) -> Option<u128> {
+        // Count addresses covered by any prefix, skipping those already covered by a
+        // strictly shorter prefix (via shortest-prefix match).  This avoids cloning or
+        // mutating the map while correctly deduplicating overlapping prefixes.
+        let mut count: u128 = 0;
+        for (prefix, _) in self.iter() {
+            if let Some((spm, _)) = self.get_spm(&prefix) {
+                if spm.prefix_len() < prefix.prefix_len() {
+                    continue;
+                }
+            }
+            let host_bits = P::num_bits() - prefix.prefix_len() as u32;
+            match 1u128
+                .checked_shl(host_bits)
+                .and_then(|c| count.checked_add(c))
+            {
+                Some(v) => count = v,
+                None => return None,
+            }
+        }
+        Some(count)
+    }
+
     /// Return a reference to the underlying table (crate-internal use only).
     #[inline(always)]
     pub(crate) fn table(&self) -> &Table<T> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -99,6 +99,59 @@ impl<P: Prefix> PrefixSet<P> {
         self.0.mem_size()
     }
 
+    /// Count the number of unique addresses covered by all prefixes in the set.
+    ///
+    /// The set is first aggregated (using [`aggregate_consistent`](Self::aggregate_consistent)),
+    /// so overlapping prefixes are counted only once. Returns `None` if the entire
+    /// address space is covered (e.g., `::/0` for IPv6), since 2<sup>num_bits</sup>
+    /// cannot be represented in a `u128`.
+    ///
+    /// ```
+    /// use prefix_trie::PrefixSet;
+    ///
+    /// # #[cfg(feature = "ipnet")]
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut set: PrefixSet<ipnet::Ipv4Net> = PrefixSet::new();
+    /// set.insert("192.0.2.0/24".parse()?);
+    /// set.insert("198.51.100.0/24".parse()?);
+    /// assert_eq!(set.address_count(), Some(512));
+    ///
+    /// // Full IPv4 space (2^32 fits in u128)
+    /// let mut full: PrefixSet<ipnet::Ipv4Net> = PrefixSet::new();
+    /// full.insert("0.0.0.0/0".parse()?);
+    /// assert_eq!(full.address_count(), Some(1u128 << 32));
+    ///
+    /// // Full IPv6 space (2^128 overflows u128)
+    /// let mut full6: PrefixSet<ipnet::Ipv6Net> = PrefixSet::new();
+    /// full6.insert("::/0".parse()?);
+    /// assert_eq!(full6.address_count(), None);
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "ipnet"))]
+    /// # fn main() {}
+    /// ```
+    pub fn address_count(&self) -> Option<u128> {
+        // Count addresses covered by any prefix, skipping those already covered by a
+        // strictly shorter prefix (via shortest-prefix match).
+        let mut count: u128 = 0;
+        for prefix in self.iter() {
+            if let Some(spm) = self.get_spm(&prefix) {
+                if spm.prefix_len() < prefix.prefix_len() {
+                    continue;
+                }
+            }
+            let host_bits = P::num_bits() - prefix.prefix_len() as u32;
+            match 1u128
+                .checked_shl(host_bits)
+                .and_then(|c| count.checked_add(c))
+            {
+                Some(v) => count = v,
+                None => return None,
+            }
+        }
+        Some(count)
+    }
+
     /// Check whether `prefix` is present in the set using exact prefix matching.
     ///
     /// ```

--- a/src/set.rs
+++ b/src/set.rs
@@ -101,8 +101,8 @@ impl<P: Prefix> PrefixSet<P> {
 
     /// Count the number of unique addresses covered by all prefixes in the set.
     ///
-    /// The set is first aggregated (using [`aggregate_consistent`](Self::aggregate_consistent)),
-    /// so overlapping prefixes are counted only once. Returns `None` if the entire
+    /// A read-only trie traversal skips prefixes covered by a shorter stored prefix, so
+    /// overlapping prefixes are counted only once. Returns `None` if the entire
     /// address space is covered (e.g., `::/0` for IPv6), since 2<sup>num_bits</sup>
     /// cannot be represented in a `u128`.
     ///
@@ -131,25 +131,7 @@ impl<P: Prefix> PrefixSet<P> {
     /// # fn main() {}
     /// ```
     pub fn address_count(&self) -> Option<u128> {
-        // Count addresses covered by any prefix, skipping those already covered by a
-        // strictly shorter prefix (via shortest-prefix match).
-        let mut count: u128 = 0;
-        for prefix in self.iter() {
-            if let Some(spm) = self.get_spm(&prefix) {
-                if spm.prefix_len() < prefix.prefix_len() {
-                    continue;
-                }
-            }
-            let host_bits = P::num_bits() - prefix.prefix_len() as u32;
-            match 1u128
-                .checked_shl(host_bits)
-                .and_then(|c| count.checked_add(c))
-            {
-                Some(v) => count = v,
-                None => return None,
-            }
-        }
-        Some(count)
+        self.0.address_count()
     }
 
     /// Check whether `prefix` is present in the set using exact prefix matching.

--- a/src/set.rs
+++ b/src/set.rs
@@ -102,9 +102,8 @@ impl<P: Prefix> PrefixSet<P> {
     /// Count the number of unique addresses covered by all prefixes in the set.
     ///
     /// A read-only trie traversal skips prefixes covered by a shorter stored prefix, so
-    /// overlapping prefixes are counted only once. Returns `None` if the entire
-    /// address space is covered (e.g., `::/0` for IPv6), since 2<sup>num_bits</sup>
-    /// cannot be represented in a `u128`.
+    /// overlapping prefixes are counted only once. Returns `None` if the count cannot be
+    /// represented in the prefix's address representation, such as a fully covered address space.
     ///
     /// ```
     /// use prefix_trie::PrefixSet;
@@ -116,12 +115,11 @@ impl<P: Prefix> PrefixSet<P> {
     /// set.insert("198.51.100.0/24".parse()?);
     /// assert_eq!(set.address_count(), Some(512));
     ///
-    /// // Full IPv4 space (2^32 fits in u128)
+    /// // Full address spaces cannot be represented in their address type.
     /// let mut full: PrefixSet<ipnet::Ipv4Net> = PrefixSet::new();
     /// full.insert("0.0.0.0/0".parse()?);
-    /// assert_eq!(full.address_count(), Some(1u128 << 32));
+    /// assert_eq!(full.address_count(), None);
     ///
-    /// // Full IPv6 space (2^128 overflows u128)
     /// let mut full6: PrefixSet<ipnet::Ipv6Net> = PrefixSet::new();
     /// full6.insert("::/0".parse()?);
     /// assert_eq!(full6.address_count(), None);
@@ -130,7 +128,7 @@ impl<P: Prefix> PrefixSet<P> {
     /// # #[cfg(not(feature = "ipnet"))]
     /// # fn main() {}
     /// ```
-    pub fn address_count(&self) -> Option<u128> {
+    pub fn address_count(&self) -> Option<P::R> {
         self.0.address_count()
     }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,6 +1,6 @@
 //! The inner node implementation.
 
-use num_traits::Zero;
+use num_traits::{CheckedAdd, One, Zero};
 
 use crate::{
     aggregate::member_coverage,
@@ -459,15 +459,15 @@ impl<T> Table<T> {
 
     /// Count addresses covered by stored prefixes without descending into sub-tries covered by an
     /// ancestor prefix.
-    pub(crate) fn address_count<P: Prefix>(&self) -> Option<u128> {
+    pub(crate) fn address_count<P: Prefix>(&self) -> Option<P::R> {
         self.address_count_at::<P>(Loc::root(), 0)
     }
 
-    fn address_count_at<P: Prefix>(&self, loc: Loc, depth: u32) -> Option<u128> {
+    fn address_count_at<P: Prefix>(&self, loc: Loc, depth: u32) -> Option<P::R> {
         let node = *self.node(loc);
         let data_bitmap = node.data_bitmap();
         let (covered_data, covered_children) = member_coverage(data_bitmap);
-        let mut count = 0u128;
+        let mut count = P::R::zero();
 
         for bit in 0..NUM_DATA as u32 {
             if data_bitmap & !covered_data & (1 << bit) == 0 {
@@ -475,12 +475,17 @@ impl<T> Table<T> {
             }
             let prefix_len = depth + DATA_BIT_TO_PREFIX[bit as usize].1 as u32;
             let host_bits = P::num_bits() - prefix_len;
-            count = count.checked_add(1u128.checked_shl(host_bits)?)?;
+            if host_bits == P::num_bits() {
+                return None;
+            }
+            let addresses = P::R::one() << host_bits as usize;
+            count = count.checked_add(&addresses)?;
         }
 
         for child in node.child_locs() {
             if covered_children & (1 << child.bit) == 0 {
-                count = count.checked_add(self.address_count_at::<P>(child, depth + K)?)?;
+                let child_count = self.address_count_at::<P>(child, depth + K)?;
+                count = count.checked_add(&child_count)?;
             }
         }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -3,6 +3,7 @@
 use num_traits::Zero;
 
 use crate::{
+    aggregate::member_coverage,
     allocator::{AllocIdx, CellAllocator, Loc, NodeAllocator, RawPtr},
     node::{
         child_bit, child_cover_mask, data_bit, data_cover_mask, extend_repr, lex_after_child,
@@ -454,6 +455,36 @@ impl<T> Table<T> {
 
     pub(crate) fn mem_size(&self) -> usize {
         self.nodes.mem_size() + self.cells.mem_size()
+    }
+
+    /// Count addresses covered by stored prefixes without descending into sub-tries covered by an
+    /// ancestor prefix.
+    pub(crate) fn address_count<P: Prefix>(&self) -> Option<u128> {
+        self.address_count_at::<P>(Loc::root(), 0)
+    }
+
+    fn address_count_at<P: Prefix>(&self, loc: Loc, depth: u32) -> Option<u128> {
+        let node = *self.node(loc);
+        let data_bitmap = node.data_bitmap();
+        let (covered_data, covered_children) = member_coverage(data_bitmap);
+        let mut count = 0u128;
+
+        for bit in 0..NUM_DATA as u32 {
+            if data_bitmap & !covered_data & (1 << bit) == 0 {
+                continue;
+            }
+            let prefix_len = depth + DATA_BIT_TO_PREFIX[bit as usize].1 as u32;
+            let host_bits = P::num_bits() - prefix_len;
+            count = count.checked_add(1u128.checked_shl(host_bits)?)?;
+        }
+
+        for child in node.child_locs() {
+            if covered_children & (1 << child.bit) == 0 {
+                count = count.checked_add(self.address_count_at::<P>(child, depth + K)?)?;
+            }
+        }
+
+        Some(count)
     }
 
     fn drop_values(&mut self) {

--- a/src/table.rs
+++ b/src/table.rs
@@ -460,6 +460,9 @@ impl<T> Table<T> {
     /// Count addresses covered by stored prefixes without descending into sub-tries covered by an
     /// ancestor prefix.
     pub(crate) fn address_count<P: Prefix>(&self) -> Option<P::R> {
+        if self.node(Loc::root()).has_data_bit(0) {
+            return None;
+        }
         self.address_count_at::<P>(Loc::root(), 0)
     }
 
@@ -475,9 +478,6 @@ impl<T> Table<T> {
             }
             let prefix_len = depth + DATA_BIT_TO_PREFIX[bit as usize].1 as u32;
             let host_bits = P::num_bits() - prefix_len;
-            if host_bits == P::num_bits() {
-                return None;
-            }
             let addresses = P::R::one() << host_bits as usize;
             count = count.checked_add(&addresses)?;
         }

--- a/src/test/address_count.rs
+++ b/src/test/address_count.rs
@@ -3,9 +3,9 @@ mod t {
     use super::super::*;
 
     /// Helper: expected address count for a prefix of given length in a `P::num_bits()`-bit space.
-    fn expected_count<P: Prefix>(prefix_len: u8) -> u128 {
+    fn expected_count<P: Prefix>(prefix_len: u8) -> P::R {
         let host_bits = P::num_bits() - prefix_len as u32;
-        1u128 << host_bits
+        P::R::one() << host_bits as usize
     }
 
     // ── PrefixMap ──────────────────────────────────────────────────────────
@@ -14,7 +14,7 @@ mod t {
     fn map_address_count_single_prefix<P: Prefix>() {
         let mut pm = Map::<P>::new();
         pm.insert(ip("10.0.0.0/24"), 1);
-        assert_eq!(pm.address_count(), Some(expected_count::<P>(24)));
+        assert!(pm.address_count() == Some(expected_count::<P>(24)));
     }
 
     #[test]
@@ -22,7 +22,7 @@ mod t {
         let mut pm = Map::<P>::new();
         pm.insert(ip("10.0.0.0/24"), 1);
         pm.insert(ip("10.0.1.0/24"), 2);
-        assert_eq!(pm.address_count(), Some(2 * expected_count::<P>(24)));
+        assert!(pm.address_count() == Some(expected_count::<P>(24) + expected_count::<P>(24)));
     }
 
     #[test]
@@ -31,7 +31,7 @@ mod t {
         let mut pm = Map::<P>::new();
         pm.insert(ip("10.0.0.0/24"), 1);
         pm.insert(ip("10.0.0.128/25"), 2);
-        assert_eq!(pm.address_count(), Some(expected_count::<P>(24)));
+        assert!(pm.address_count() == Some(expected_count::<P>(24)));
     }
 
     #[test]
@@ -39,39 +39,30 @@ mod t {
         let mut pm = Map::<P>::new();
         pm.insert(ip("10.0.0.0/24"), 1);
         pm.insert(ip("10.0.0.0/24"), 2);
-        assert_eq!(pm.address_count(), Some(expected_count::<P>(24)));
+        assert!(pm.address_count() == Some(expected_count::<P>(24)));
     }
 
     #[test]
     fn map_address_count_empty<P: Prefix>() {
         let pm = Map::<P>::new();
-        assert_eq!(pm.address_count(), Some(0));
+        assert!(pm.address_count() == Some(P::R::zero()));
     }
 
     #[test]
     fn map_address_count_full_space<P: Prefix>() {
-        // /0 covers the entire address space: 2^num_bits addresses
+        // /0 covers the entire address space, which does not fit in P::R.
         let mut pm = Map::<P>::new();
         pm.insert(ip("0.0.0.0/0"), 1);
-        if P::num_bits() >= 128 {
-            // 2^128 overflows u128
-            assert_eq!(pm.address_count(), None);
-        } else {
-            assert_eq!(pm.address_count(), Some(1u128 << P::num_bits()));
-        }
+        assert!(pm.address_count().is_none());
     }
 
     #[test]
     fn map_address_count_two_halves<P: Prefix>() {
-        // Two /1 prefixes cover the full space: 2^(n-1) + 2^(n-1) = 2^n
+        // Two /1 prefixes cover the full space, which does not fit in P::R.
         let mut pm = Map::<P>::new();
         pm.insert(ip("0.0.0.0/1"), 1);
         pm.insert(ip("128.0.0.0/1"), 2);
-        if P::num_bits() >= 128 {
-            assert_eq!(pm.address_count(), None);
-        } else {
-            assert_eq!(pm.address_count(), Some(1u128 << P::num_bits()));
-        }
+        assert!(pm.address_count().is_none());
     }
 
     #[test]
@@ -82,7 +73,7 @@ mod t {
         pm.insert(ip("10.0.0.0/16"), 1);
         pm.insert(ip("10.0.0.0/24"), 2);
         pm.insert(ip("10.0.1.0/24"), 3);
-        assert_eq!(pm.address_count(), Some(expected_count::<P>(16)));
+        assert!(pm.address_count() == Some(expected_count::<P>(16)));
     }
 
     #[test]
@@ -92,10 +83,7 @@ mod t {
         pm.insert(ip("10.0.0.0/16"), 1);
         pm.insert(ip("10.0.0.0/24"), 2); // inside /16
         pm.insert(ip("11.0.0.0/24"), 3); // outside /16
-        assert_eq!(
-            pm.address_count(),
-            Some(expected_count::<P>(16) + expected_count::<P>(24))
-        );
+        assert!(pm.address_count() == Some(expected_count::<P>(16) + expected_count::<P>(24)));
     }
 
     // ── PrefixSet ──────────────────────────────────────────────────────────
@@ -103,45 +91,37 @@ mod t {
     #[test]
     fn set_address_count_single_prefix<P: Prefix + Copy + PartialEq>() {
         let set = PrefixSet::<P>::from_iter([ip("10.0.0.0/24")]);
-        assert_eq!(set.address_count(), Some(expected_count::<P>(24)));
+        assert!(set.address_count() == Some(expected_count::<P>(24)));
     }
 
     #[test]
     fn set_address_count_overlapping<P: Prefix + Copy + PartialEq>() {
         let set = PrefixSet::<P>::from_iter([ip("10.0.0.0/24"), ip("10.0.0.128/25")]);
-        assert_eq!(set.address_count(), Some(expected_count::<P>(24)));
+        assert!(set.address_count() == Some(expected_count::<P>(24)));
     }
 
     #[test]
     fn set_address_count_empty<P: Prefix + Copy + PartialEq>() {
         let set = PrefixSet::<P>::new();
-        assert_eq!(set.address_count(), Some(0));
+        assert!(set.address_count() == Some(P::R::zero()));
     }
 
     #[test]
     fn set_address_count_full_space<P: Prefix + Copy + PartialEq>() {
         let set = PrefixSet::<P>::from_iter([ip("0.0.0.0/0")]);
-        if P::num_bits() >= 128 {
-            assert_eq!(set.address_count(), None);
-        } else {
-            assert_eq!(set.address_count(), Some(1u128 << P::num_bits()));
-        }
+        assert!(set.address_count().is_none());
     }
 
     #[test]
     fn set_address_count_non_overlapping<P: Prefix + Copy + PartialEq>() {
         let set = PrefixSet::<P>::from_iter([ip("10.0.0.0/24"), ip("10.0.1.0/24")]);
-        assert_eq!(set.address_count(), Some(2 * expected_count::<P>(24)));
+        assert!(set.address_count() == Some(expected_count::<P>(24) + expected_count::<P>(24)));
     }
 
     #[test]
     fn set_address_count_two_halves<P: Prefix + Copy + PartialEq>() {
         let set = PrefixSet::<P>::from_iter([ip("0.0.0.0/1"), ip("128.0.0.0/1")]);
-        if P::num_bits() >= 128 {
-            assert_eq!(set.address_count(), None);
-        } else {
-            assert_eq!(set.address_count(), Some(1u128 << P::num_bits()));
-        }
+        assert!(set.address_count().is_none());
     }
 
     // ── Instantiations ─────────────────────────────────────────────────────
@@ -227,8 +207,8 @@ mod joint {
         let mut pm: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
         pm.insert("0.0.0.0/0".parse().unwrap(), 1);
         let count = pm.address_count();
-        // 2^32 fits in u128
-        assert_eq!(count.0, Some(1u128 << 32));
+        // 2^32 does not fit in u32.
+        assert_eq!(count.0, None);
         assert_eq!(count.1, Some(0));
     }
 
@@ -238,7 +218,7 @@ mod joint {
         pm.insert("::/0".parse().unwrap(), 1);
         let count = pm.address_count();
         assert_eq!(count.0, Some(0));
-        assert_eq!(count.1, None); // 2^128 overflows u128
+        assert_eq!(count.1, None); // 2^128 does not fit in u128
     }
 
     #[test]
@@ -247,7 +227,7 @@ mod joint {
         pm.insert("0.0.0.0/0".parse().unwrap(), 1);
         pm.insert("::/0".parse().unwrap(), 2);
         let count = pm.address_count();
-        assert_eq!(count.0, Some(1u128 << 32));
+        assert_eq!(count.0, None);
         assert_eq!(count.1, None);
     }
 

--- a/src/test/address_count.rs
+++ b/src/test/address_count.rs
@@ -1,0 +1,267 @@
+#[generic_tests::define]
+mod t {
+    use super::super::*;
+
+    /// Helper: expected address count for a prefix of given length in a `P::num_bits()`-bit space.
+    fn expected_count<P: Prefix>(prefix_len: u8) -> u128 {
+        let host_bits = P::num_bits() as u32 - prefix_len as u32;
+        1u128 << host_bits
+    }
+
+    // ── PrefixMap ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn map_address_count_single_prefix<P: Prefix>() {
+        let mut pm = Map::<P>::new();
+        pm.insert(ip("10.0.0.0/24"), 1);
+        assert_eq!(pm.address_count(), Some(expected_count::<P>(24)));
+    }
+
+    #[test]
+    fn map_address_count_non_overlapping<P: Prefix>() {
+        let mut pm = Map::<P>::new();
+        pm.insert(ip("10.0.0.0/24"), 1);
+        pm.insert(ip("10.0.1.0/24"), 2);
+        assert_eq!(pm.address_count(), Some(2 * expected_count::<P>(24)));
+    }
+
+    #[test]
+    fn map_address_count_overlapping<P: Prefix>() {
+        // /24 covers /25; the /25 should not add extra addresses after aggregation
+        let mut pm = Map::<P>::new();
+        pm.insert(ip("10.0.0.0/24"), 1);
+        pm.insert(ip("10.0.0.128/25"), 2);
+        assert_eq!(pm.address_count(), Some(expected_count::<P>(24)));
+    }
+
+    #[test]
+    fn map_address_count_duplicate_prefix<P: Prefix>() {
+        let mut pm = Map::<P>::new();
+        pm.insert(ip("10.0.0.0/24"), 1);
+        pm.insert(ip("10.0.0.0/24"), 2);
+        assert_eq!(pm.address_count(), Some(expected_count::<P>(24)));
+    }
+
+    #[test]
+    fn map_address_count_empty<P: Prefix>() {
+        let pm = Map::<P>::new();
+        assert_eq!(pm.address_count(), Some(0));
+    }
+
+    #[test]
+    fn map_address_count_full_space<P: Prefix>() {
+        // /0 covers the entire address space: 2^num_bits addresses
+        let mut pm = Map::<P>::new();
+        pm.insert(ip("0.0.0.0/0"), 1);
+        if P::num_bits() >= 128 {
+            // 2^128 overflows u128
+            assert_eq!(pm.address_count(), None);
+        } else {
+            assert_eq!(pm.address_count(), Some(1u128 << P::num_bits()));
+        }
+    }
+
+    #[test]
+    fn map_address_count_two_halves<P: Prefix>() {
+        // Two /1 prefixes cover the full space: 2^(n-1) + 2^(n-1) = 2^n
+        let mut pm = Map::<P>::new();
+        pm.insert(ip("0.0.0.0/1"), 1);
+        pm.insert(ip("128.0.0.0/1"), 2);
+        if P::num_bits() >= 128 {
+            assert_eq!(pm.address_count(), None);
+        } else {
+            assert_eq!(pm.address_count(), Some(1u128 << P::num_bits()));
+        }
+    }
+
+    #[test]
+    fn map_address_count_subprefix_inside_supernet<P: Prefix>() {
+        // /16 + two /24s inside the /16 → aggregated to just /16
+        // 10.0.0.0/16 covers 10.0.0.0 – 10.0.255.255
+        let mut pm = Map::<P>::new();
+        pm.insert(ip("10.0.0.0/16"), 1);
+        pm.insert(ip("10.0.0.0/24"), 2);
+        pm.insert(ip("10.0.1.0/24"), 3);
+        assert_eq!(pm.address_count(), Some(expected_count::<P>(16)));
+    }
+
+    #[test]
+    fn map_address_count_mixed_overlapping_and_distinct<P: Prefix>() {
+        // /16 (covers 10.0.0.0/24) + a distinct /24
+        let mut pm = Map::<P>::new();
+        pm.insert(ip("10.0.0.0/16"), 1);
+        pm.insert(ip("10.0.0.0/24"), 2); // inside /16
+        pm.insert(ip("11.0.0.0/24"), 3); // outside /16
+        assert_eq!(
+            pm.address_count(),
+            Some(expected_count::<P>(16) + expected_count::<P>(24))
+        );
+    }
+
+    // ── PrefixSet ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn set_address_count_single_prefix<P: Prefix + Copy + PartialEq>() {
+        let set = PrefixSet::<P>::from_iter([ip("10.0.0.0/24")]);
+        assert_eq!(set.address_count(), Some(expected_count::<P>(24)));
+    }
+
+    #[test]
+    fn set_address_count_overlapping<P: Prefix + Copy + PartialEq>() {
+        let set = PrefixSet::<P>::from_iter([ip("10.0.0.0/24"), ip("10.0.0.128/25")]);
+        assert_eq!(set.address_count(), Some(expected_count::<P>(24)));
+    }
+
+    #[test]
+    fn set_address_count_empty<P: Prefix + Copy + PartialEq>() {
+        let set = PrefixSet::<P>::new();
+        assert_eq!(set.address_count(), Some(0));
+    }
+
+    #[test]
+    fn set_address_count_full_space<P: Prefix + Copy + PartialEq>() {
+        let set = PrefixSet::<P>::from_iter([ip("0.0.0.0/0")]);
+        if P::num_bits() >= 128 {
+            assert_eq!(set.address_count(), None);
+        } else {
+            assert_eq!(set.address_count(), Some(1u128 << P::num_bits()));
+        }
+    }
+
+    #[test]
+    fn set_address_count_non_overlapping<P: Prefix + Copy + PartialEq>() {
+        let set = PrefixSet::<P>::from_iter([ip("10.0.0.0/24"), ip("10.0.1.0/24")]);
+        assert_eq!(set.address_count(), Some(2 * expected_count::<P>(24)));
+    }
+
+    #[test]
+    fn set_address_count_two_halves<P: Prefix + Copy + PartialEq>() {
+        let set = PrefixSet::<P>::from_iter([ip("0.0.0.0/1"), ip("128.0.0.0/1")]);
+        if P::num_bits() >= 128 {
+            assert_eq!(set.address_count(), None);
+        } else {
+            assert_eq!(set.address_count(), Some(1u128 << P::num_bits()));
+        }
+    }
+
+    // ── Instantiations ─────────────────────────────────────────────────────
+
+    #[instantiate_tests(<(u32, u8)>)]
+    mod raw32 {}
+
+    #[instantiate_tests(<(u64, u8)>)]
+    mod raw64 {}
+
+    #[instantiate_tests(<(u128, u8)>)]
+    mod raw128 {}
+
+    #[cfg(feature = "ipnet")]
+    #[instantiate_tests(<ipnet::Ipv4Net>)]
+    mod ipv4net {}
+
+    #[cfg(feature = "ipnet")]
+    #[instantiate_tests(<ipnet::Ipv6Net>)]
+    mod ipv6net {}
+
+    #[cfg(feature = "ipnetwork")]
+    #[instantiate_tests(<ipnetwork::Ipv4Network>)]
+    mod ipv4network {}
+
+    #[cfg(feature = "ipnetwork")]
+    #[instantiate_tests(<ipnetwork::Ipv6Network>)]
+    mod ipv6network {}
+
+    #[cfg(feature = "cidr")]
+    #[instantiate_tests(<cidr::Ipv4Cidr>)]
+    mod ipv4cidr {}
+
+    #[cfg(feature = "cidr")]
+    #[instantiate_tests(<cidr::Ipv6Cidr>)]
+    mod ipv6cidr {}
+
+    #[cfg(feature = "cidr")]
+    #[instantiate_tests(<cidr::Ipv4Inet>)]
+    mod ipv4inet {}
+
+    #[cfg(feature = "cidr")]
+    #[instantiate_tests(<cidr::Ipv6Inet>)]
+    mod ipv6inet {}
+}
+
+// ── JointPrefixMap tests (ipnet only, not generic) ────────────────────────
+
+#[cfg(feature = "ipnet")]
+#[cfg(test)]
+mod joint {
+    use crate::joint::JointPrefixMap;
+
+    #[test]
+    fn joint_map_address_count_basic() {
+        let mut pm: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+        pm.insert("192.0.2.0/24".parse().unwrap(), 1);
+        pm.insert("2001:db8::/48".parse().unwrap(), 2);
+        let count = pm.address_count();
+        assert_eq!(count.0, Some(256));
+        assert_eq!(count.1, Some(1u128 << 80));
+    }
+
+    #[test]
+    fn joint_map_address_count_empty() {
+        let pm: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+        let count = pm.address_count();
+        assert_eq!(count.0, Some(0));
+        assert_eq!(count.1, Some(0));
+    }
+
+    #[test]
+    fn joint_map_address_count_full_ipv4_only() {
+        let mut pm: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+        pm.insert("0.0.0.0/0".parse().unwrap(), 1);
+        let count = pm.address_count();
+        // 2^32 fits in u128
+        assert_eq!(count.0, Some(1u128 << 32));
+        assert_eq!(count.1, Some(0));
+    }
+
+    #[test]
+    fn joint_map_address_count_full_ipv6_only() {
+        let mut pm: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+        pm.insert("::/0".parse().unwrap(), 1);
+        let count = pm.address_count();
+        assert_eq!(count.0, Some(0));
+        assert_eq!(count.1, None); // 2^128 overflows u128
+    }
+
+    #[test]
+    fn joint_map_address_count_both_full() {
+        let mut pm: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+        pm.insert("0.0.0.0/0".parse().unwrap(), 1);
+        pm.insert("::/0".parse().unwrap(), 2);
+        let count = pm.address_count();
+        assert_eq!(count.0, Some(1u128 << 32));
+        assert_eq!(count.1, None);
+    }
+
+    #[test]
+    fn joint_map_address_count_overlapping_v4() {
+        let mut pm: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+        pm.insert("192.0.2.0/24".parse().unwrap(), 1);
+        pm.insert("192.0.2.128/25".parse().unwrap(), 2);
+        pm.insert("198.51.100.0/24".parse().unwrap(), 3);
+        let count = pm.address_count();
+        assert_eq!(count.0, Some(512));
+        assert_eq!(count.1, Some(0));
+    }
+
+    #[test]
+    fn joint_map_address_count_overlapping_v6() {
+        let mut pm: JointPrefixMap<ipnet::IpNet, u32> = JointPrefixMap::new();
+        pm.insert("2001:db8::/48".parse().unwrap(), 1);
+        pm.insert("2001:db8::/64".parse().unwrap(), 2); // inside /48
+        pm.insert("2001:db9::/48".parse().unwrap(), 3); // distinct
+        let count = pm.address_count();
+        // /48 + /48 = 2 * 2^80
+        assert_eq!(count.0, Some(0));
+        assert_eq!(count.1, Some(2 * (1u128 << 80)));
+    }
+}

--- a/src/test/address_count.rs
+++ b/src/test/address_count.rs
@@ -4,7 +4,7 @@ mod t {
 
     /// Helper: expected address count for a prefix of given length in a `P::num_bits()`-bit space.
     fn expected_count<P: Prefix>(prefix_len: u8) -> u128 {
-        let host_bits = P::num_bits() as u32 - prefix_len as u32;
+        let host_bits = P::num_bits() - prefix_len as u32;
         1u128 << host_bits
     }
 
@@ -193,7 +193,7 @@ mod t {
 #[cfg(feature = "ipnet")]
 #[cfg(test)]
 mod joint {
-    use crate::joint::JointPrefixMap;
+    use crate::joint::{JointPrefixMap, JointPrefixSet};
 
     #[test]
     fn joint_map_address_count_basic() {
@@ -203,6 +203,15 @@ mod joint {
         let count = pm.address_count();
         assert_eq!(count.0, Some(256));
         assert_eq!(count.1, Some(1u128 << 80));
+    }
+
+    #[test]
+    fn joint_set_address_count_basic() {
+        let mut set: JointPrefixSet<ipnet::IpNet> = JointPrefixSet::new();
+        set.insert("192.0.2.0/24".parse().unwrap());
+        set.insert("192.0.2.128/25".parse().unwrap());
+        set.insert("2001:db8::/48".parse().unwrap());
+        assert_eq!(set.address_count(), (Some(256), Some(1u128 << 80)));
     }
 
     #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,5 +1,5 @@
 use ipnet::Ipv4Net;
-use num_traits::NumCast;
+use num_traits::{NumCast, One, Zero};
 
 use super::*;
 mod address_count;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2,6 +2,7 @@ use ipnet::Ipv4Net;
 use num_traits::NumCast;
 
 use super::*;
+mod address_count;
 mod aggregate;
 
 type Map<P> = PrefixMap<P, u32>;


### PR DESCRIPTION
~~Adds `address_count()` to `PrefixMap`, `PrefixSet`, and `JointPrefixMap` — a method that counts the number of unique IP addresses covered by all prefixes in the collection, useful for analytics like measuring what fraction of the address space a routing table covers.~~

~~The implementation iterates all prefixes and uses `get_spm` (shortest-prefix match) to skip any prefix already covered by a strictly shorter prefix, then sums `2^host_bits` for each remaining entry. This approach requires no `Clone` bound and avoids cloning or mutating the collection. `JointPrefixMap` delegates to each underlying `PrefixMap` and returns `(Option<u128>, Option<u128>)` for the two address families. Returns `None` when the entire address space is covered (2^num_bits overflows `u128`), e.g. `::/0` for IPv6.~~

~~This is part of migrating [`ipnet-trie`](https://github.com/bgpkit/ipnet-trie) to use `prefix-trie` directly. `address_count` is the last utility method from that crate not yet available here.~~

This still adds `address_count()` for `PrefixMap`, `PrefixSet`, and `JointPrefixMap`, and also adds it to `JointPrefixSet`.

The implementation now walks each trie once instead of calling `get_spm` for every prefix:
- Counts each stored prefix that is not covered by a shorter stored prefix.
- Skips the entries and child subtries already covered by that prefix.
- Reuses the existing bitmap coverage helpers, with no cloning or mutation.
- Keeps `None` for a count that cannot fit in `u128`, such as full IPv6 coverage.
